### PR TITLE
feat: enable alert/prompt dismissal when app entering background

### DIFF
--- a/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
@@ -170,8 +170,12 @@ public class RNPromptFragment extends DialogFragment implements DialogInterface.
 
     @Override
     public void onClick(DialogInterface dialog, int which) {
-        if (mInputText != null && mListener != null) {
-            mListener.onConfirm(which, mInputText.getText().toString());
+        if (mListener != null) {
+            if (mInputText != null) {
+                mListener.onConfirm(which, mInputText.getText().toString());    
+            } else {
+                mListener.onClick(dialog, which);
+            }
         }
     }
 

--- a/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
@@ -99,60 +99,62 @@ public class RNPromptFragment extends DialogFragment implements DialogInterface.
         AlertDialog alertDialog = builder.create();
 
         Boolean isShowInput = arguments.getBoolean(ARG_SHOW_INPUT, false);
-        if (isShowInput) {
-            // input style
-            LayoutInflater inflater = LayoutInflater.from(activityContext);
-            final EditText input;
-            switch (style) {
-                case "shimo":
-                    input = (EditText) inflater.inflate(R.layout.edit_text, null);
-                    break;
-                default:
-                    input = new EditText(activityContext);
-            }
-
-            // input type
-            int type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
-            if (arguments.containsKey(ARG_TYPE)) {
-                String typeString = arguments.getString(ARG_TYPE);
-                if (typeString != null) {
-                    switch (typeString) {
-                        case "secure-text":
-                            type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD;
-                            break;
-                        case "numeric":
-                            type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_CLASS_NUMBER;
-                            break;
-                        case "email-address":
-                            type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
-                            break;
-                        case "phone-pad":
-                            type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_CLASS_PHONE;
-                            break;
-                        case "plain-text":
-                        default:
-                            type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
-                    }
-                }
-            }
-            input.setInputType(type);
-
-            if (arguments.containsKey(ARG_DEFAULT_VALUE)) {
-                String defaultValue = arguments.getString(ARG_DEFAULT_VALUE);
-                if (defaultValue != null) {
-                    input.setText(defaultValue);
-                    int textLength = input.getText().length();
-                    input.setSelection(textLength, textLength);
-                }
-            }
-
-            if (arguments.containsKey(ARG_PLACEHOLDER)) {
-                input.setHint(arguments.getString(ARG_PLACEHOLDER));
-            }
-            alertDialog.setView(input, 50, 15, 50, 0);
-
-            mInputText = input;
+        if (!isShowInput) {
+            return alertDialog;
         }
+        
+        // input style
+        LayoutInflater inflater = LayoutInflater.from(activityContext);
+        final EditText input;
+        switch (style) {
+            case "shimo":
+                input = (EditText) inflater.inflate(R.layout.edit_text, null);
+                break;
+            default:
+                input = new EditText(activityContext);
+        }
+
+        // input type
+        int type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
+        if (arguments.containsKey(ARG_TYPE)) {
+            String typeString = arguments.getString(ARG_TYPE);
+            if (typeString != null) {
+                switch (typeString) {
+                    case "secure-text":
+                        type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD;
+                        break;
+                    case "numeric":
+                        type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_CLASS_NUMBER;
+                        break;
+                    case "email-address":
+                        type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
+                        break;
+                    case "phone-pad":
+                        type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_CLASS_PHONE;
+                        break;
+                    case "plain-text":
+                    default:
+                        type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
+                }
+            }
+        }
+        input.setInputType(type);
+
+        if (arguments.containsKey(ARG_DEFAULT_VALUE)) {
+            String defaultValue = arguments.getString(ARG_DEFAULT_VALUE);
+            if (defaultValue != null) {
+                input.setText(defaultValue);
+                int textLength = input.getText().length();
+                input.setSelection(textLength, textLength);
+            }
+        }
+
+        if (arguments.containsKey(ARG_PLACEHOLDER)) {
+            input.setHint(arguments.getString(ARG_PLACEHOLDER));
+        }
+        alertDialog.setView(input, 50, 15, 50, 0);
+
+        mInputText = input;
         
         return alertDialog;
     }

--- a/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptFragment.java
@@ -25,6 +25,7 @@ public class RNPromptFragment extends DialogFragment implements DialogInterface.
     /* package */ static final String ARG_STYLE = "style";
     /* package */ static final String ARG_DEFAULT_VALUE = "defaultValue";
     /* package */ static final String ARG_PLACEHOLDER = "placeholder";
+    /* package */ static final String ARG_SHOW_INPUT = "showInput";
 
     private EditText mInputText;
 
@@ -97,73 +98,79 @@ public class RNPromptFragment extends DialogFragment implements DialogInterface.
 
         AlertDialog alertDialog = builder.create();
 
-        // input style
-        LayoutInflater inflater = LayoutInflater.from(activityContext);
-        final EditText input;
-        switch (style) {
-            case "shimo":
-                input = (EditText) inflater.inflate(R.layout.edit_text, null);
-                break;
-            default:
-                input = new EditText(activityContext);
-        }
+        Boolean isShowInput = arguments.getBoolean(ARG_SHOW_INPUT, false);
+        if (isShowInput) {
+            // input style
+            LayoutInflater inflater = LayoutInflater.from(activityContext);
+            final EditText input;
+            switch (style) {
+                case "shimo":
+                    input = (EditText) inflater.inflate(R.layout.edit_text, null);
+                    break;
+                default:
+                    input = new EditText(activityContext);
+            }
 
-        // input type
-        int type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
-        if (arguments.containsKey(ARG_TYPE)) {
-            String typeString = arguments.getString(ARG_TYPE);
-            if (typeString != null) {
-                switch (typeString) {
-                    case "secure-text":
-                        type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD;
-                        break;
-                    case "numeric":
-                        type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_CLASS_NUMBER;
-                        break;
-                    case "email-address":
-                        type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
-                        break;
-                    case "phone-pad":
-                        type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_CLASS_PHONE;
-                        break;
-                    case "plain-text":
-                    default:
-                        type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
+            // input type
+            int type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
+            if (arguments.containsKey(ARG_TYPE)) {
+                String typeString = arguments.getString(ARG_TYPE);
+                if (typeString != null) {
+                    switch (typeString) {
+                        case "secure-text":
+                            type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD;
+                            break;
+                        case "numeric":
+                            type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_CLASS_NUMBER;
+                            break;
+                        case "email-address":
+                            type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
+                            break;
+                        case "phone-pad":
+                            type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_CLASS_PHONE;
+                            break;
+                        case "plain-text":
+                        default:
+                            type = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
+                    }
                 }
             }
-        }
-        input.setInputType(type);
+            input.setInputType(type);
 
-        if (arguments.containsKey(ARG_DEFAULT_VALUE)) {
-            String defaultValue = arguments.getString(ARG_DEFAULT_VALUE);
-            if (defaultValue != null) {
-                input.setText(defaultValue);
-                int textLength = input.getText().length();
-                input.setSelection(textLength, textLength);
+            if (arguments.containsKey(ARG_DEFAULT_VALUE)) {
+                String defaultValue = arguments.getString(ARG_DEFAULT_VALUE);
+                if (defaultValue != null) {
+                    input.setText(defaultValue);
+                    int textLength = input.getText().length();
+                    input.setSelection(textLength, textLength);
+                }
             }
-        }
 
-        if (arguments.containsKey(ARG_PLACEHOLDER)) {
-            input.setHint(arguments.getString(ARG_PLACEHOLDER));
-        }
-        alertDialog.setView(input, 50, 15, 50, 0);
+            if (arguments.containsKey(ARG_PLACEHOLDER)) {
+                input.setHint(arguments.getString(ARG_PLACEHOLDER));
+            }
+            alertDialog.setView(input, 50, 15, 50, 0);
 
-        mInputText = input;
+            mInputText = input;
+        }
+        
         return alertDialog;
     }
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         Dialog dialog = this.createDialog(getActivity(), getArguments());
-        if (mInputText.requestFocus()) {
-            dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+        if (mInputText != null) {
+            if (mInputText.requestFocus()) {
+                dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+            }
         }
         return dialog;
     }
 
     @Override
     public void onClick(DialogInterface dialog, int which) {
-        if (mListener != null) {
+        if (mInputText != null && mListener != null) {
             mListener.onConfirm(which, mInputText.getText().toString());
         }
     }

--- a/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
@@ -68,8 +68,13 @@ public class RNPromptModule extends ReactContextBaseJavaModule implements Lifecy
 
     @Override
     public void onHostPause() {
-        // Don't show the dialog if the host is paused.
         mIsInForeground = false;
+        FragmentManagerHelper fragmentManagerHelper = getFragmentManagerHelper();
+        if (fragmentManagerHelper != null) {
+            fragmentManagerHelper.dismissExisting();
+        } else {
+            FLog.w(DialogModule.class, "onHostPause called but no FragmentManager found");
+        }
     }
 
     @Override

--- a/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
@@ -94,6 +94,9 @@ public class RNPromptModule extends ReactContextBaseJavaModule implements Lifecy
         }
     }
 
+    /**
+     * reference: https://github.com/facebook/react-native/commit/0cd2f77116cbac8c5a402a355c2d359163429962
+     */
     @ReactMethod
     public void alertWithArgs(
          ReadableMap options, final Callback callback) {

--- a/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
@@ -255,7 +255,12 @@ public class RNPromptModule extends ReactContextBaseJavaModule implements Lifecy
 
         @Override
         public void onClick(DialogInterface dialog, int which) {
-            onConfirm(which, "");
+            if (!mCallbackConsumed) {
+                if (getReactApplicationContext().hasActiveCatalystInstance()) {
+                    mCallback.invoke(ACTION_BUTTON_CLICKED, which);
+                    mCallbackConsumed = true;
+                }
+            }
         }
 
         public void onConfirm(int which, String input) {

--- a/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
@@ -93,6 +93,45 @@ public class RNPromptModule extends ReactContextBaseJavaModule implements Lifecy
         }
     }
 
+    @ReactMethod
+    public void alertWithArgs(
+         ReadableMap options, final Callback callback) {
+        final FragmentManagerHelper fragmentManagerHelper = getFragmentManagerHelper();
+        if (fragmentManagerHelper == null) {
+            FLog.w(RNPromptModule.class, "Tried to show an alert while not attached to an Activity");
+            return;
+        }
+
+        final Bundle args = new Bundle();
+        if (options.hasKey(KEY_TITLE)) {
+            args.putString(RNPromptFragment.ARG_TITLE, options.getString(KEY_TITLE));
+        }        
+        if (options.hasKey(KEY_MESSAGE)) {
+            args.putString(RNPromptFragment.ARG_MESSAGE, options.getString(KEY_MESSAGE));
+        }
+        if (options.hasKey(KEY_BUTTON_POSITIVE)) {
+            args.putString(RNPromptFragment.ARG_BUTTON_POSITIVE, options.getString(KEY_BUTTON_POSITIVE));
+        }
+        if (options.hasKey(KEY_BUTTON_NEGATIVE)) {
+            args.putString(RNPromptFragment.ARG_BUTTON_NEGATIVE, options.getString(KEY_BUTTON_NEGATIVE));
+        }
+        if (options.hasKey(KEY_BUTTON_NEUTRAL)) {
+            args.putString(RNPromptFragment.ARG_BUTTON_NEUTRAL, options.getString(KEY_BUTTON_NEUTRAL));
+        }
+        if (options.hasKey(KEY_ITEMS)) {
+            ReadableArray items = options.getArray(KEY_ITEMS);
+            CharSequence[] itemsArray = new CharSequence[items.size()];
+            for (int i = 0; i < items.size(); i++) {
+                itemsArray[i] = items.getString(i);
+            }
+            args.putCharSequenceArray(RNPromptFragment.ARG_ITEMS, itemsArray);
+        }
+        if (options.hasKey(KEY_CANCELABLE)) {
+            args.putBoolean(KEY_CANCELABLE, options.getBoolean(KEY_CANCELABLE));
+        }
+        fragmentManagerHelper.showNewAlert(mIsInForeground, args, callback);
+    }
+
 
     @ReactMethod
     public void promptWithArgs(ReadableMap options, final Callback callback) {

--- a/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
@@ -42,6 +42,7 @@ public class RNPromptModule extends ReactContextBaseJavaModule implements Lifecy
     /* package */ static final String KEY_STYLE = "style";
     /* package */ static final String KEY_DEFAULT_VALUE = "defaultValue";
     /* package */ static final String KEY_PLACEHOLDER = "placeholder";
+    /* package */ static final String KEY_SHOW_INPUT = "showInput";
 
     /* package */ static final Map<String, Object> CONSTANTS = MapBuilder.<String, Object>of(
             ACTION_BUTTON_CLICKED, ACTION_BUTTON_CLICKED,
@@ -183,6 +184,7 @@ public class RNPromptModule extends ReactContextBaseJavaModule implements Lifecy
         if (options.hasKey(KEY_PLACEHOLDER)) {
             args.putString(KEY_PLACEHOLDER, options.getString(KEY_PLACEHOLDER));
         }
+        args.putBoolean(KEY_SHOW_INPUT, true);
         fragmentManagerHelper.showNewAlert(mIsInForeground, args, callback);
     }
 

--- a/index.android.js
+++ b/index.android.js
@@ -53,7 +53,6 @@ type AlertOptions = {
     cancelable?: ?boolean,
     userInterfaceStyle?: 'unspecified' | 'light' | 'dark',
     onDismiss?: ?() => void,
-    ...
 };
 
 /**
@@ -73,21 +72,24 @@ type ButtonsArray = Array<{
         onPress?: ?Function,
 }>;
 
+type AlertButtonStyle = 'default' | 'cancel' | 'destructive';
+
 type Buttons = Array<{
     text?: string,
     onPress?: ?Function,
     isPreferred?: boolean,
     style?: AlertButtonStyle,
-    ...
 }>;
 
-const ACTION_KEYS = {
-    buttonClicked: 'buttonClicked',
-    dismissed: 'dismissed',
-    buttonPositive: -1,
-    buttonNegative: -2,
-    buttonNeutral: -3,
-}
+type DialogOptions = {
+    title?: string,
+    message?: string,
+    buttonPositive?: string,
+    buttonNegative?: string,
+    buttonNeutral?: string,
+    items?: Array<string>,
+    cancelable?: boolean,
+};
 
 function alert(
     title: ?string,
@@ -220,4 +222,4 @@ function prompt(
 export default {
     alert,
     prompt
-}
+};

--- a/index.android.js
+++ b/index.android.js
@@ -91,6 +91,9 @@ type DialogOptions = {
     cancelable?: boolean,
 };
 
+/**
+ * reference: https://github.com/facebook/react-native/blob/e71b094b24ea5f135308b1e66c86216d9d693403/Libraries/Alert/Alert.js#L43-L114
+ */
 function alert(
     title: ?string,
     message?: ?string,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-prompt-android",
-    "version": "0.3.4",
+    "version": "0.3.4-exodus.1",
     "files": ["index*","android/*","package.json"],
     "description": "Polyfill for Alert.prompt on Android",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "android"
     ],
     "scripts": {
-        "lint": "eslint ./"
+        "lint": "eslint ./ --ignore-pattern '**/Example/*'"
     },
     "devDependencies": {
         "babel-eslint": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "react-native-prompt-android",
     "version": "0.3.4",
+    "files": ["index*","android/*","package.json"],
     "description": "Polyfill for Alert.prompt on Android",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "react-native-prompt-android",
+    "name": "@exodus/react-native-prompt-android",
     "version": "0.3.4-exodus.1",
     "files": ["index*","android/*","package.json"],
     "description": "Polyfill for Alert.prompt on Android",


### PR DESCRIPTION
# Summary

As discussed [here](https://github.com/ExodusMovement/exodus-mobile/pull/12004/files#r1062153489), we need to unify the Android native prompt/alert into `react-native-prompt-android`.

Initially, this library only support `Alert.prompt`, this PR added:
1.  `Alert.alert` feature
2. Prompt/Alert dismissal when app enter background

related ticket: https://app.asana.com/0/1202170937152401/1202654758999294