### PR TITLE
fix(alert): ensure default button shown

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -113,7 +113,7 @@ function alert(
     // At most three buttons (neutral, negative, positive). Ignore rest.
     // The text 'OK' should be probably localized. iOS Alert does that in native.
     const defaultPositiveText = 'OK';
-    const validButtons: Buttons = buttons
+    const validButtons: Buttons = (buttons && buttons.length > 0)
         ? buttons.slice(0, 3)
         : [{text: defaultPositiveText}];
     const buttonPositive = validButtons.pop();


### PR DESCRIPTION
Based on [Andrej suggestion](https://github.com/ExodusMovement/exodus-mobile/pull/14922#issuecomment-1592998398), we need to add default button on simple alert for android. Use `Alert.alert('test')` will result in alert that is not closable.

Root cause is `buttons` value is always set to empty array, hence it would not always revert back to default button.

Closes: https://app.asana.com/0/1202170937152401/1204834500330440/f