### PR TITLE
chore: upgrade to 0.3.4-exodus.8 for RN 0.85

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ android {
 
 repositories {
     mavenLocal()
-    jcenter()
+    mavenCentral()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$projectDir/../../../node_modules/react-native/android"

--- a/package.json
+++ b/package.json
@@ -1,27 +1,31 @@
 {
-    "name": "@exodus/react-native-prompt-android",
-    "version": "0.3.4-exodus.7",
-    "files": ["index*","android/*","package.json"],
-    "description": "Polyfill for Alert.prompt on Android",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/shimohq/react-native-prompt-android"
-    },
-    "license": "MIT",
-    "keywords": [
-        "react-component",
-        "react-native",
-        "prompt",
-        "Alert",
-        "ios",
-        "android"
-    ],
-    "scripts": {
-        "lint": "eslint ./ --ignore-pattern '**/Example/*'"
-    },
-    "devDependencies": {
-        "babel-eslint": "^6.1.2",
-        "eslint": "^2.13.1",
-        "eslint-plugin-react": "^4.3.0"
-    }
+  "name": "@exodus/react-native-prompt-android",
+  "version": "0.3.4-exodus.8",
+  "files": [
+    "index*",
+    "android/*",
+    "package.json"
+  ],
+  "description": "Polyfill for Alert.prompt on Android",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shimohq/react-native-prompt-android"
+  },
+  "license": "MIT",
+  "keywords": [
+    "react-component",
+    "react-native",
+    "prompt",
+    "Alert",
+    "ios",
+    "android"
+  ],
+  "scripts": {
+    "lint": "eslint ./ --ignore-pattern '**/Example/*'"
+  },
+  "devDependencies": {
+    "babel-eslint": "^6.1.2",
+    "eslint": "^2.13.1",
+    "eslint-plugin-react": "^4.3.0"
+  }
 }


### PR DESCRIPTION
## Summary

Version bump to `0.3.4-exodus.8` for RN 0.85 upgrade.
Part of [ExodusMovement/exodus-mobile#38221](https://github.com/ExodusMovement/exodus-mobile/issues/38221).

## Audit

<details>
<summary>Audit Report</summary>

# Step 4: Security Audit for react-native-prompt-android
Date: 2026-04-23 11:47 UTC
Scan scope: Diff: 27f6c528d358..exodus-rn85
Added lines scanned: 414

## Summary
| Severity | Findings |
|----------|----------|
| CRITICAL | 0 |
| HIGH | 4 |
| MEDIUM | 0 |

## Detailed Findings
### HIGH: Hardcoded URL (4 occurrences)
```
+     * reference: https://github.com/facebook/react-native/commit/0cd2f77116cbac8c5a402a355c2d359163429962
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+ * reference: https://github.com/facebook/react-native/blob/e71b094b24ea5f135308b1e66c86216d9d693403/Libraries/Alert/Alert.js#L43-L114
```

</details>

## Patches

<details>
<summary>Patch Analysis</summary>

# Step 1: Patch Analysis for react-native-prompt-android
Date: 2026-04-23 11:47 UTC

## Summary
- Fork branch: `exodus`
- Merge-base: `27f6c528d358`
- Exodus commits: **23**

## Commit Log
```
d2cb093 Merge pull request #15 from ExodusForks/ap/exodus.7
a062f26 chore: bump version
9f3fd9f Merge pull request #14 from ExodusForks/ap/fix_android_jank
4a43e33 fix: android jank
0b18bbb Merge pull request #13 from ExodusForks/ap/adjust_dimens
0318b2f chore: release 0.3.4-exodus.6
4434df7 fix: style
b3eb80f Merge pull request #12 from ExodusForks/ap/fix_uppercase
131090b fix: version
ba4a325 fix: uppercase
93b05ba Merge pull request #11 from ExodusForks/ap/fix_narrow_screens
1f771de chore: version 0.3.4-exodus.4
e1af2ad fix: narrow screens
7b2bbe3 Merge pull request #10 from ExodusMovement/ap/new_prompt
1250121 chore: bump version
d616639 feat: new cool style
a0eba02 Merge pull request #9 from ExodusMovement/nafis/bump-0.3.4-exodus.2
90d716c 0.3.4-exodus.2
e1dceed fix(alert): ensure default button shown (#8)
9fab69c 0.3.4-exodus.1 (#7)
e53ac3a chore: revert bump version from PR #2 (#6)
ee2fb3e Merge pull request #1 from ExodusMovement/nafis/initial-settings-after-fork
bd1bdcb chore: add exodus as project scope
```

## Categorized Patches
```
OTHER: Merge pull request #15 from ExodusForks/ap/exodus.7
PACKAGING: chore: bump version
OTHER: Merge pull request #14 from ExodusForks/ap/fix_android_jank
BUG_FIX: fix: android jank
OTHER: Merge pull request #13 from ExodusForks/ap/adjust_dimens
PACKAGING: chore: release 0.3.4-exodus.6
BUG_FIX: fix: style
OTHER: Merge pull request #12 from ExodusForks/ap/fix_uppercase
BUG_FIX: fix: version
BUG_FIX: fix: uppercase
OTHER: Merge pull request #11 from ExodusForks/ap/fix_narrow_screens
PACKAGING: chore: version 0.3.4-exodus.4
BUG_FIX: fix: narrow screens
OTHER: Merge pull request #10 from ExodusMovement/ap/new_prompt
PACKAGING: chore: bump version
FEATURE: feat: new cool style
OTHER: Merge pull request #9 from ExodusMovement/nafis/bump-0.3.4-exodus.2
OTHER: 0.3.4-exodus.2
BUG_FIX: fix(alert): ensure default button shown (#8)
OTHER: 0.3.4-exodus.1 (#7)
PACKAGING: chore: revert bump version from PR #2 (#6)
OTHER: Merge pull request #1 from ExodusMovement/nafis/initial-settings-after-fork
PACKAGING: chore: add exodus as project scope
```

## Security-Critical Patches
None identified

</details>

## Test Plan

- [ ] Update `src/package.json` in exodus-mobile-upgrade worktree
- [ ] `yarn ios:base` builds
- [ ] `yarn android:base` builds
- [ ] Functional test