### PR TITLE
feat(android): opt-in alerts over the top activity, plus a host ticker

### DIFF
--- a/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
+++ b/android/src/main/java/im/shimo/react/prompt/RNPromptModule.java
@@ -2,8 +2,12 @@ package im.shimo.react.prompt;
 
 
 import android.app.Activity;
+import android.app.Application;
+import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Callback;
@@ -15,7 +19,10 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.dialog.DialogModule;
+
+import java.lang.ref.WeakReference;
 
 import java.util.Map;
 
@@ -43,15 +50,21 @@ public class RNPromptModule extends ReactContextBaseJavaModule implements Lifecy
     /* package */ static final String KEY_DEFAULT_VALUE = "defaultValue";
     /* package */ static final String KEY_PLACEHOLDER = "placeholder";
     /* package */ static final String KEY_SHOW_INPUT = "showInput";
+    /* package */ static final String KEY_SHOW_OVER_TOP_ACTIVITY = "showOverTopActivity";
+    /* package */ static final String TICK_EVENT = "PromptAndroidTick";
 
     /* package */ static final Map<String, Object> CONSTANTS = MapBuilder.<String, Object>of(
             ACTION_BUTTON_CLICKED, ACTION_BUTTON_CLICKED,
             ACTION_DISMISSED, ACTION_DISMISSED,
             KEY_BUTTON_POSITIVE, DialogInterface.BUTTON_POSITIVE,
             KEY_BUTTON_NEGATIVE, DialogInterface.BUTTON_NEGATIVE,
-            KEY_BUTTON_NEUTRAL, DialogInterface.BUTTON_NEUTRAL);
+            KEY_BUTTON_NEUTRAL, DialogInterface.BUTTON_NEUTRAL,
+            KEY_SHOW_OVER_TOP_ACTIVITY, true);
 
     private boolean mIsInForeground;
+    // getCurrentActivity() only reports ours; this sees third-party activities too.
+    private WeakReference<Activity> mTopActivity = new WeakReference<>(null);
+    private volatile Handler mTicker;
 
     public RNPromptModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -65,6 +78,67 @@ public class RNPromptModule extends ReactContextBaseJavaModule implements Lifecy
     @Override
     public void initialize() {
         getReactApplicationContext().addLifecycleEventListener(this);
+        Application app = (Application) getReactApplicationContext().getApplicationContext();
+        app.registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
+            @Override public void onActivityResumed(Activity a) { mTopActivity = new WeakReference<>(a); }
+            @Override public void onActivityCreated(Activity a, Bundle b) {}
+            @Override public void onActivityStarted(Activity a) {}
+            @Override public void onActivityPaused(Activity a) {}
+            @Override public void onActivityStopped(Activity a) {}
+            @Override public void onActivitySaveInstanceState(Activity a, Bundle b) {}
+            @Override public void onActivityDestroyed(Activity a) {}
+        });
+    }
+
+    // Paired with the option above: React Native stops JS timers while our host is paused.
+    @ReactMethod
+    public void startTicker(double intervalMs) {
+        stopTicker();
+        final long interval = (long) intervalMs;
+        mTicker = new Handler(Looper.getMainLooper());
+        mTicker.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                ReactApplicationContext ctx = getReactApplicationContext();
+                if (ctx.hasActiveCatalystInstance()) {
+                    ctx.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(TICK_EVENT, null);
+                }
+                // Re-read, never capture: re-posting to a dropped handler ticks forever.
+                Handler ticker = mTicker;
+                if (ticker != null) ticker.postDelayed(this, interval);
+            }
+        }, interval);
+    }
+
+    @ReactMethod
+    public void stopTicker() {
+        final Handler ticker = mTicker;
+        mTicker = null;
+        if (ticker != null) ticker.removeCallbacksAndMessages(null);
+    }
+
+    // Not a DialogFragment: recreation restores it without its listener, so nothing settles.
+    private void showAlertOverTopActivity(final Bundle args, final Callback callback) {
+        final Activity activity = mTopActivity.get();
+        if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
+            FLog.w(RNPromptModule.class, "Tried to show an alert with no activity on top");
+            if (callback != null) callback.invoke(ACTION_DISMISSED);
+            return;
+        }
+
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                PromptFragmentListener listener =
+                        callback == null ? null : new PromptFragmentListener(callback);
+                RNPromptFragment fragment = new RNPromptFragment();
+                fragment.setListener(listener);
+                Dialog dialog = fragment.createDialog(activity, args);
+                dialog.setCancelable(!args.containsKey(KEY_CANCELABLE) || args.getBoolean(KEY_CANCELABLE));
+                if (listener != null) dialog.setOnDismissListener(listener);
+                dialog.show();
+            }
+        });
     }
 
     @Override
@@ -85,6 +159,7 @@ public class RNPromptModule extends ReactContextBaseJavaModule implements Lifecy
     @Override
     public void onHostResume() {
         mIsInForeground = true;
+        stopTicker();
         // Check if a dialog has been created while the host was paused, so that we can show it now.
         FragmentManagerHelper fragmentManagerHelper = getFragmentManagerHelper();
         if (fragmentManagerHelper != null) {
@@ -100,12 +175,6 @@ public class RNPromptModule extends ReactContextBaseJavaModule implements Lifecy
     @ReactMethod
     public void alertWithArgs(
          ReadableMap options, final Callback callback) {
-        final FragmentManagerHelper fragmentManagerHelper = getFragmentManagerHelper();
-        if (fragmentManagerHelper == null) {
-            FLog.w(RNPromptModule.class, "Tried to show an alert while not attached to an Activity");
-            return;
-        }
-
         final Bundle args = new Bundle();
         if (options.hasKey(KEY_TITLE)) {
             args.putString(RNPromptFragment.ARG_TITLE, options.getString(KEY_TITLE));
@@ -132,6 +201,16 @@ public class RNPromptModule extends ReactContextBaseJavaModule implements Lifecy
         }
         if (options.hasKey(KEY_CANCELABLE)) {
             args.putBoolean(KEY_CANCELABLE, options.getBoolean(KEY_CANCELABLE));
+        }
+        if (options.hasKey(KEY_SHOW_OVER_TOP_ACTIVITY) && options.getBoolean(KEY_SHOW_OVER_TOP_ACTIVITY)) {
+            showAlertOverTopActivity(args, callback);
+            return;
+        }
+
+        final FragmentManagerHelper fragmentManagerHelper = getFragmentManagerHelper();
+        if (fragmentManagerHelper == null) {
+            FLog.w(RNPromptModule.class, "Tried to show an alert while not attached to an Activity");
+            return;
         }
         fragmentManagerHelper.showNewAlert(mIsInForeground, args, callback);
     }

--- a/index.android.js
+++ b/index.android.js
@@ -53,6 +53,7 @@ type AlertOptions = {
     cancelable?: ?boolean,
     userInterfaceStyle?: 'unspecified' | 'light' | 'dark',
     onDismiss?: ?() => void,
+    showOverTopActivity?: ?boolean,
 };
 
 /**
@@ -89,6 +90,7 @@ type DialogOptions = {
     buttonNeutral?: string,
     items?: Array<string>,
     cancelable?: boolean,
+    showOverTopActivity?: boolean,
 };
 
 /**
@@ -109,6 +111,9 @@ function alert(
 
     if (options && options.cancelable) {
         config.cancelable = options.cancelable;
+    }
+    if (options && options.showOverTopActivity) {
+        config.showOverTopActivity = true;
     }
     // At most three buttons (neutral, negative, positive). Ignore rest.
     // The text 'OK' should be probably localized. iOS Alert does that in native.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@exodus/react-native-prompt-android",
-    "version": "0.3.4-exodus.7",
+    "version": "0.3.4-exodus.8",
     "files": ["index*","android/*","package.json"],
     "description": "Polyfill for Alert.prompt on Android",
     "repository": {


### PR DESCRIPTION
## What

Adds one opt-in option to `Alert.alert` on Android — `showOverTopActivity` — which hosts the dialog on whichever activity is currently on top instead of React Native's. Plus `startTicker`/`stopTicker`: a native clock that keeps firing while the RN host activity is paused.

## Why

When a third-party SDK presents its own Activity inside our process (Intercom's messenger, Google Sign-In, the image picker, passkeys), two things break:

- An `Alert.alert` belongs to *our* Activity, which is paused, so `showNewAlert` parks the fragment until host resume — the customer sees the dialog only after leaving that screen.
- React Native suspends JS timers while our Activity is paused (measured: 0 ticks across 42s), so nothing can decide *when* to prompt.

Exodus needs a consent prompt to appear inside an Intercom conversation. The option addresses the first problem, the ticker the second.

## Notes for review

- **Fully opt-in.** The option is absent by default and every existing call site takes the unchanged fragment path. `promptWithArgs` is untouched.
- The key is published through the existing `getConstants()` map — the same dual use as `buttonPositive` — so callers feature-detect the option instead of gating on a version number.
- The new path **reuses `RNPromptFragment.createDialog()`** rather than rebuilding the dialog, so there is no second builder to drift and `RNPromptFragment.java` needed no changes at all. It shows a plain `Dialog` rather than the `DialogFragment` because a fragment restored after activity recreation comes back without its listener, so the callback would never fire and the caller would wait forever.
- `mTicker` is `volatile` and the Runnable **re-reads** it instead of capturing a local: `stopTicker()` runs on the native modules thread while the Runnable runs on the main looper, so capturing would let a mid-tick stop re-post to a handler nobody holds any more and tick until process death.
- The ticker stands itself down in `onHostResume`, so it cannot be repurposed as a background scheduler.
- The `getFragmentManagerHelper()` lookup in `alertWithArgs` moved below the args build, because the new path must not require our own Activity to exist — it may have been destroyed while a third-party one is on top.
- Known and deliberate: `registerActivityLifecycleCallbacks` is never unregistered, so a dev JS reload leaks a module instance. This matches the file's existing pattern (`addLifecycleEventListener(this)` in `initialize()` has no teardown either) and has no production impact, since there is one instance per process.

## Verification

Built from source and exercised on an Android emulator against Intercom's messenger:

- dialog renders over `IntercomRootActivity`; Continue and Cancel both settle the callback
- 14 ticks at exact 3.000s intervals while our activity was paused, against 0 from JS timers
- `stopTicker()` ends the chain — no tick after stop
- `showOverTopActivity` readable from `getConstants()`

**One open question.** The dialog does not appear to take input focus on a foreign activity (`mCurrentFocus` stays on the host's window), so a back press reaches that activity rather than dismissing the dialog — `onDismiss` never fired across one back press and two taps outside. That is acceptable for our consent flow since both buttons settle, but if you know whether a back press can close the host activity underneath a still-showing dialog, it would be good to confirm.