### PR TITLE
chore: release 0.3.4-exodus.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@exodus/react-native-prompt-android",
-    "version": "0.3.4-exodus.8",
+    "version": "0.3.4-exodus.9",
     "files": ["index*","android/*","package.json"],
     "description": "Polyfill for Alert.prompt on Android",
     "repository": {


### PR DESCRIPTION
Bumps to `0.3.4-exodus.9` so the `showOverTopActivity` + ticker change from #17 can be published.

`0.3.4-exodus.8` cannot be used: that version was already published to npm on 2026-04-27, before #17 landed, so the number is taken and `npm publish` rejects it. The published `.8` tarball contains none of #17's changes.

